### PR TITLE
Add method to load single config file

### DIFF
--- a/src/Configula/Config.php
+++ b/src/Configula/Config.php
@@ -101,6 +101,26 @@ class Config implements ArrayAccess, Iterator, Countable
         return count($this->configSettings);
     }
 
+    /**
+     * Load configuration values from a file
+     *
+     * @param  string $configFilePath An absolute path to the configuration file
+     * @return int    The number of configuration settings loaded
+     * @throws \Exception If cannot read from Configuration file
+     */
+    public function loadConfgFile($configFilePath)
+    {
+        if (! is_readable($configFilePath)) {
+            throw new ConfigulaException("Cannot read config file!  Does it exist?  Is it readable?");
+        }
+
+        $config = $this->parseConfigFile($configFilePath);
+
+        $this->configSettings = $this->mergeConfigArrays($this->configSettings, $config);
+
+        return count($this->configSettings);
+    }
+
     // --------------------------------------------------------------
 
     /**

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -24,6 +24,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase {
     {
         parent::setUp();
         $this->configPath = realpath(__DIR__ . '/fixtures/main/');
+        $this->configPhpGoodFilePath = $this->configPath . '/phpgood.php';
     }
 
     // --------------------------------------------------------------
@@ -261,6 +262,46 @@ class ConfigTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals('newvalue', $obj->d['valc']['b']);
 
         unlink($this->configPath . $ds . 'phpgood.local.php');
+    }
+
+    // --------------------------------------------------------------
+
+    public function testLoadConfigFileLoadsFile()
+    {
+        $obj = new Configula\Config();
+        $obj->loadConfgFile($this->configPhpGoodFilePath);
+
+        $this->assertEquals('value', $obj->a);
+    }
+
+    // --------------------------------------------------------------
+
+    /**
+     * Test that single config value load properly overwrites previous values
+     */
+    public function testLoadConfigFileOverridesCurrectValue()
+    {
+        if ( ! is_writable($this->configPath)) {
+            $this->markTestSkipped("Could not write temporary file to config path.");
+            return;
+        }
+
+        $ds = DIRECTORY_SEPARATOR;
+        $code = '<?php
+            $config = array();
+            $config["d"]["vala"] = "newvalue";
+            $config["d"]["valc"]["b"] = "newvalue";
+            /*EOF*/';
+
+        $obj = new Configula\Config($this->configPath);
+        file_put_contents($this->configPath . $ds . 'phpextra.php', $code);
+        $obj->loadConfgFile($this->configPath . $ds . 'phpextra.php');
+
+        $this->assertEquals('bye', $obj->d['valb']);
+        $this->assertEquals('newvalue', $obj->d['vala']);
+
+        unlink($this->configPath . $ds . 'phpextra.php');
+
     }
 
     // --------------------------------------------------------------

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,7 +17,7 @@
 
 //Files to ensure exist
 $checkFiles['autoload'] = __DIR__.'/../vendor/autoload.php';
-$checkFiles[] = __DIR__.'/../vendor/symfony/yaml/Symfony/Component/Yaml/Yaml.php';
+$checkFiles[] = __DIR__.'/../vendor/symfony/yaml/Yaml.php';
 
 //Check 'Em
 foreach($checkFiles as $file) {


### PR DESCRIPTION
* Add method `loadConfigFile` to allow for loading a single config file
  explicitly as opposed to loading an entire directory

This helps deal with the majority of slight deviations from Configula's
conventions