### PR TITLE
When getItem is call on a nested var return null even if the value is…

### DIFF
--- a/src/Configula/Config.php
+++ b/src/Configula/Config.php
@@ -178,7 +178,8 @@ class Config implements ArrayAccess, Iterator, Countable
         } elseif (strpos($item, '.') !== FALSE) {
 
             $cs = $this->configSettings;
-            if ($val = $this->getNestedVar($cs, $item)) {
+            $val = $this->getNestedVar($cs, $item);
+            if ($val !== null) {
                 return $val;
             }
 


### PR DESCRIPTION
When getItem is call on a nested var return null even if the value is  0 or empty array