### PR TITLE
Add `ReturnTypeWillChange` attribute to ConfigValues::offsetGet

### DIFF
--- a/src/ConfigValues.php
+++ b/src/ConfigValues.php
@@ -300,6 +300,7 @@ class ConfigValues implements IteratorAggregate, Countable, ArrayAccess
      * @param  mixed $offset
      * @return mixed
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->get($offset);


### PR DESCRIPTION
## Description

As ConfigValues inherits from ArrayAccess, not having a return type hint
in `offsetGet` causes a deprecation warning.
Add `ReturnTypeWillChange` attribute for now.

## Motivation and context

Fix deprecation warning

```
 PHP Deprecated:  Return type of Configula\ConfigValues::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [X] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [X] My pull request addresses exactly one patch/feature.
- [X] I have created a branch for this patch/feature.
- [X] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
